### PR TITLE
Add rumqttc test

### DIFF
--- a/comparison/src/rumqttc/Cargo.toml
+++ b/comparison/src/rumqttc/Cargo.toml
@@ -31,5 +31,5 @@ noisy_float = { version = "0.2.0" }
 num-traits = "0.2.15"
 once_cell = "1.13.0"
 pretty_env_logger = "0.4.0"
-async-std = { version = "=1.12.0", features = ["attributes", "unstable"] }
 rumqttc = "0.17.0"
+tokio = { version = "1.22.0", features = ["rt-multi-thread", "macros", "time"] }

--- a/comparison/src/rumqttc/Cargo.toml
+++ b/comparison/src/rumqttc/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "rumqttc-test"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "rumqttc_pub_thr"
+path = "src/rumqttc_pub_thr/main.rs"
+
+[[bin]]
+name = "rumqttc_sub_thr"
+path = "src/rumqttc_sub_thr/main.rs"
+
+[[bin]]
+name = "rumqttc_ping"
+path = "src/rumqttc_ping/main.rs"
+
+[[bin]]
+name = "rumqttc_pong"
+path = "src/rumqttc_pong/main.rs"
+
+[dependencies]
+anyhow = "1.0.58"
+chrono = "0.4.19"
+clap = { version = "3.2.11", features = ["derive"] }
+futures = "0.3.21"
+humantime = "2.1.0"
+itertools = "0.10.3"
+log = "0.4.17"
+noisy_float = { version = "0.2.0" }
+num-traits = "0.2.15"
+once_cell = "1.13.0"
+pretty_env_logger = "0.4.0"
+async-std = { version = "=1.12.0", features = ["attributes", "unstable"] }
+rumqttc = "0.17.0"

--- a/comparison/src/rumqttc/Makefile
+++ b/comparison/src/rumqttc/Makefile
@@ -1,0 +1,15 @@
+all: build install_kafka
+
+install_kafka:
+	@./scripts/install-kafka.sh
+
+build: build_throughput build_latency
+
+build_throughput:
+	@cargo build --release --bin kafka_pub_thr --bin kafka_sub_thr
+
+build_latency:
+	@cargo build --release --bin kafka_ping --bin kafka_pong
+
+clean:
+	@cargo clean

--- a/comparison/src/rumqttc/mosquitto.conf
+++ b/comparison/src/rumqttc/mosquitto.conf
@@ -1,0 +1,5 @@
+listener 1883
+allow_anonymous true
+max_inflight_messages 0
+max_queued_messages 0
+# queue_qos0_messages true

--- a/comparison/src/rumqttc/rust-toolchain.toml
+++ b/comparison/src/rumqttc/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.65.0"
+components = ["rust-docs", "rustfmt", "clippy"]
+# targets = ["x86_64-unknown-linux-gnu"]
+profile = "default"

--- a/comparison/src/rumqttc/rustfmt.toml
+++ b/comparison/src/rumqttc/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2021"
+format_code_in_doc_comments = true
+imports_granularity = "Crate"

--- a/comparison/src/rumqttc/scripts/clean_mosquitto.sh
+++ b/comparison/src/rumqttc/scripts/clean_mosquitto.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+groups | grep -q docker || {
+    echo \"Warning: You may not have permission to execute docker. Try this command:\" >&2
+    echo \"         usermod -a -G docker YOUR_USERNAME\" >&2
+}
+
+VERSION=${1:-2.0.15}
+
+MQTT_DOCKER="eclipse-mosquitto:$VERSION"
+CONTAINER_ID=$(docker ps -a -q --filter "ancestor=$MQTT_DOCKER" --format="{{.ID}}")
+
+if [ ! -z "$CONTAINER_ID" ]; then
+    docker rm $(docker stop $CONTAINER_ID) &> /dev/null
+fi

--- a/comparison/src/rumqttc/scripts/run_mosquitto.sh
+++ b/comparison/src/rumqttc/scripts/run_mosquitto.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+# Move to working dir
+script_dir="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+cd "$script_dir/.."
+
+groups | grep -q docker || {
+    echo \"Warning: You may not have permission to execute docker. Try this command:\" >&2
+    echo \"         usermod -a -G docker YOUR_USERNAME\" >&2
+}
+
+VERSION=${1:-2.0.15}
+CONFIG=${2:-$script_dir/../mosquitto.conf}
+PORT=${3:-1883}
+CPUS=${4:-0,1}
+
+docker run \
+    --init \
+    --cpuset-cpus $CPUS \
+    -p $PORT:1883 \
+    --rm \
+    -v $CONFIG:/mosquitto/config/mosquitto.conf \
+    eclipse-mosquitto:$VERSION

--- a/comparison/src/rumqttc/src/lib.rs
+++ b/comparison/src/rumqttc/src/lib.rs
@@ -1,4 +1,6 @@
-use rumqttc::QoS;
+use anyhow::Result;
+use rumqttc::{AsyncClient, EventLoop, MqttOptions, QoS};
+use std::net::SocketAddr;
 
 pub const DEFAULT_THROUGHPUT_TOPIC: &str = "THROUGHPUT";
 pub const DEFAULT_PING_TOPIC: &str = "PING";
@@ -6,78 +8,17 @@ pub const DEFAULT_PONG_TOPIC: &str = "PONG";
 pub const DEFAULT_GROUP_ID: &str = "DUMMY_GROUP";
 pub const DEFAULT_QOS: QoS = QoS::AtLeastOnce;
 pub const DEFAULT_CAP_SIZE: usize = 10;
+pub const PACKET_HEADER_SIZE: usize = 14;
 
-// pub struct AsyncStdRuntime;
-
-// impl AsyncRuntime for AsyncStdRuntime {
-//     type Delay = Pin<Box<dyn Future<Output = ()> + Send>>;
-
-//     fn spawn<T>(task: T)
-//     where
-//         T: Future<Output = ()> + Send + 'static,
-//     {
-//         async_std::task::spawn(task);
-//     }
-
-//     fn delay_for(duration: Duration) -> Self::Delay {
-//         Box::pin(async_std::task::sleep(duration))
-//     }
-// }
-
-// pub type AsyncStdStreamConsumer = StreamConsumer<DefaultConsumerContext, AsyncStdRuntime>;
-// pub type AsyncStdFutureProducer = FutureProducer<DefaultClientContext, AsyncStdRuntime>;
-
-// #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-// pub struct KeyVal {
-//     pub key: String,
-//     pub val: String,
-// }
-
-// impl KeyVal {
-//     pub fn new<K, V>(key: K, val: V) -> Self
-//     where
-//         K: ToString,
-//         V: ToString,
-//     {
-//         Self {
-//             key: key.to_string(),
-//             val: val.to_string(),
-//         }
-//     }
-// }
-
-// impl FromStr for KeyVal {
-//     type Err = anyhow::Error;
-
-//     fn from_str(text: &str) -> Result<Self, Self::Err> {
-//         let (key, val) = text
-//             .split_once('=')
-//             .ok_or_else(|| anyhow!("Expect 'KEY=VALUE' string, but get {}", text))?;
-//         Ok(Self {
-//             key: key.to_string(),
-//             val: val.to_string(),
-//         })
-//     }
-// }
-
-// impl fmt::Display for KeyVal {
-//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-//         write!(f, "{}={}", self.key, self.val)
-//     }
-// }
-
-// pub trait MqttErrorExt {
-//     fn to_anyhow(self) -> anyhow::Error;
-// }
-
-// impl MqttErrorExt for ConnectError {
-//     fn to_anyhow(self) -> anyhow::Error {
-//         anyhow!("{}", self.to_string())
-//     }
-// }
-
-// impl MqttErrorExt for ClientError {
-//     fn to_anyhow(self) -> anyhow::Error {
-//         anyhow!("{}", self.to_string())
-//     }
-// }
+pub fn create_client(
+    name: &str,
+    broker_addr: SocketAddr,
+    max_payload_size: usize,
+) -> Result<(AsyncClient, EventLoop)> {
+    let mut client_config =
+        MqttOptions::new(name, broker_addr.ip().to_string(), broker_addr.port());
+    let max_packet_size = max_payload_size + PACKET_HEADER_SIZE;
+    client_config.set_max_packet_size(max_packet_size, max_packet_size);
+    let (client, event_loop) = AsyncClient::new(client_config, DEFAULT_CAP_SIZE);
+    Ok((client, event_loop))
+}

--- a/comparison/src/rumqttc/src/lib.rs
+++ b/comparison/src/rumqttc/src/lib.rs
@@ -1,0 +1,83 @@
+use rumqttc::QoS;
+
+pub const DEFAULT_THROUGHPUT_TOPIC: &str = "THROUGHPUT";
+pub const DEFAULT_PING_TOPIC: &str = "PING";
+pub const DEFAULT_PONG_TOPIC: &str = "PONG";
+pub const DEFAULT_GROUP_ID: &str = "DUMMY_GROUP";
+pub const DEFAULT_QOS: QoS = QoS::AtLeastOnce;
+pub const DEFAULT_CAP_SIZE: usize = 10;
+
+// pub struct AsyncStdRuntime;
+
+// impl AsyncRuntime for AsyncStdRuntime {
+//     type Delay = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+//     fn spawn<T>(task: T)
+//     where
+//         T: Future<Output = ()> + Send + 'static,
+//     {
+//         async_std::task::spawn(task);
+//     }
+
+//     fn delay_for(duration: Duration) -> Self::Delay {
+//         Box::pin(async_std::task::sleep(duration))
+//     }
+// }
+
+// pub type AsyncStdStreamConsumer = StreamConsumer<DefaultConsumerContext, AsyncStdRuntime>;
+// pub type AsyncStdFutureProducer = FutureProducer<DefaultClientContext, AsyncStdRuntime>;
+
+// #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+// pub struct KeyVal {
+//     pub key: String,
+//     pub val: String,
+// }
+
+// impl KeyVal {
+//     pub fn new<K, V>(key: K, val: V) -> Self
+//     where
+//         K: ToString,
+//         V: ToString,
+//     {
+//         Self {
+//             key: key.to_string(),
+//             val: val.to_string(),
+//         }
+//     }
+// }
+
+// impl FromStr for KeyVal {
+//     type Err = anyhow::Error;
+
+//     fn from_str(text: &str) -> Result<Self, Self::Err> {
+//         let (key, val) = text
+//             .split_once('=')
+//             .ok_or_else(|| anyhow!("Expect 'KEY=VALUE' string, but get {}", text))?;
+//         Ok(Self {
+//             key: key.to_string(),
+//             val: val.to_string(),
+//         })
+//     }
+// }
+
+// impl fmt::Display for KeyVal {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//         write!(f, "{}={}", self.key, self.val)
+//     }
+// }
+
+// pub trait MqttErrorExt {
+//     fn to_anyhow(self) -> anyhow::Error;
+// }
+
+// impl MqttErrorExt for ConnectError {
+//     fn to_anyhow(self) -> anyhow::Error {
+//         anyhow!("{}", self.to_string())
+//     }
+// }
+
+// impl MqttErrorExt for ClientError {
+//     fn to_anyhow(self) -> anyhow::Error {
+//         anyhow!("{}", self.to_string())
+//     }
+// }

--- a/comparison/src/rumqttc/src/lib.rs
+++ b/comparison/src/rumqttc/src/lib.rs
@@ -6,7 +6,7 @@ pub const DEFAULT_THROUGHPUT_TOPIC: &str = "THROUGHPUT";
 pub const DEFAULT_PING_TOPIC: &str = "PING";
 pub const DEFAULT_PONG_TOPIC: &str = "PONG";
 pub const DEFAULT_GROUP_ID: &str = "DUMMY_GROUP";
-pub const DEFAULT_QOS: QoS = QoS::AtLeastOnce;
+pub const DEFAULT_QOS: QoS = QoS::AtMostOnce;
 pub const DEFAULT_CAP_SIZE: usize = 10;
 pub const PACKET_HEADER_SIZE: usize = 14;
 

--- a/comparison/src/rumqttc/src/rumqttc_ping/main.rs
+++ b/comparison/src/rumqttc/src/rumqttc_ping/main.rs
@@ -1,0 +1,182 @@
+mod opts;
+
+use anyhow::{anyhow, ensure, Context, Result};
+use clap::Parser;
+use log::{error, info, trace};
+use once_cell::sync::Lazy;
+use opts::Opts;
+use rumqttc::{AsyncClient, Event, EventLoop, MqttOptions, Packet};
+use rumqttc_test::{DEFAULT_CAP_SIZE, DEFAULT_QOS};
+use std::{
+    process,
+    time::{Duration, SystemTime},
+};
+
+static SINCE: Lazy<SystemTime> = Lazy::new(SystemTime::now);
+const MIN_PAYLOAD_SIZE: usize = 16;
+
+struct PayloadInfo {
+    pub ping_id: u32,
+    pub msg_idx: u32,
+    pub rtt: Duration,
+}
+
+#[async_std::main]
+async fn main() -> Result<()> {
+    pretty_env_logger::init();
+
+    let opts = Opts::parse();
+    let timeout = opts.timeout;
+
+    let future = run_latency_benchmark(opts);
+    if let Some(timeout) = timeout {
+        async_std::future::timeout(timeout, future)
+            .await
+            .map_err(|_| anyhow!("timeout"))??;
+    } else {
+        future.await?;
+    }
+
+    Ok(())
+}
+
+async fn run_latency_benchmark(opts: Opts) -> Result<()> {
+    let ping_id = process::id();
+    info!("Start ping {}", ping_id);
+
+    let client_config = MqttOptions::new(
+        env!("CARGO_PKG_NAME"),
+        opts.broker.ip().to_string(),
+        opts.broker.port(),
+    );
+    let (client, mut event_loop) = AsyncClient::new(client_config, DEFAULT_CAP_SIZE);
+    client.subscribe(&opts.pong_topic, DEFAULT_QOS).await?;
+
+    for count in 0.. {
+        send(&opts, &client, ping_id, count).await?;
+        if !recv(&opts, ping_id, &mut event_loop).await? {
+            panic!("Failed to receive pong message.");
+        }
+        async_std::task::sleep(Duration::from_secs_f64(opts.interval)).await;
+    }
+
+    Ok(())
+}
+
+fn generate_payload(size: usize, ping_id: u32, msg_idx: u32) -> Vec<u8> {
+    assert!(
+        size >= MIN_PAYLOAD_SIZE,
+        "The minimum payload size is {} bytes",
+        MIN_PAYLOAD_SIZE
+    );
+    let since = *SINCE; // the SINCE is inited earlier than the next SystemTime::now()
+    let dur = SystemTime::now().duration_since(since).unwrap();
+    let micros = dur.as_micros() as u64;
+
+    let ping_id_bytes = ping_id.to_le_bytes();
+    let msg_idx_bytes = msg_idx.to_le_bytes();
+    let time_bytes = micros.to_le_bytes();
+
+    let mut payload = vec![0u8; size];
+    payload[0..4].copy_from_slice(&ping_id_bytes);
+    payload[4..8].copy_from_slice(&msg_idx_bytes);
+    payload[8..16].copy_from_slice(&time_bytes);
+    payload
+}
+
+fn parse_payload(payload: &[u8], expect_payload_size: usize) -> Result<PayloadInfo> {
+    let payload_size = payload.len();
+    ensure!(
+        payload_size >= MIN_PAYLOAD_SIZE,
+        "The payload size ({} bytes) is less than the required minimum {} bytes",
+        payload_size,
+        MIN_PAYLOAD_SIZE
+    );
+
+    let ping_id_bytes = &payload[0..4];
+    let msg_idx_bytes = &payload[4..8];
+    let time_bytes = &payload[8..16];
+
+    let micros = u64::from_le_bytes(time_bytes.try_into().unwrap());
+    let since = *SINCE + Duration::from_micros(micros);
+    let rtt = SystemTime::now()
+        .duration_since(since)
+        .with_context(|| "the timestamp goes backward")?;
+
+    let ping_id = u32::from_le_bytes(ping_id_bytes.try_into().unwrap());
+    let msg_idx = u32::from_le_bytes(msg_idx_bytes.try_into().unwrap());
+
+    ensure!(
+        payload.len() == expect_payload_size,
+        "Expect payload size to be {} bytes, but get {} bytes",
+        expect_payload_size,
+        payload_size
+    );
+
+    Ok(PayloadInfo {
+        msg_idx,
+        rtt,
+        ping_id,
+    })
+}
+
+async fn send(opts: &Opts, client: &AsyncClient, ping_id: u32, msg_idx: u32) -> Result<()> {
+    let payload = generate_payload(opts.payload_size, ping_id, msg_idx);
+
+    trace!(
+        "Send a ping with ping_id {} and msg_idx {}",
+        ping_id,
+        msg_idx
+    );
+    client
+        .publish(&opts.ping_topic, DEFAULT_QOS, false, payload)
+        .await?;
+    Ok(())
+}
+
+async fn recv(opts: &Opts, ping_id: u32, event_loop: &mut EventLoop) -> Result<bool> {
+    const RECV_TIMEOUT: Duration = Duration::from_secs(1);
+
+    let publish = loop {
+        let poll = event_loop.poll();
+        let result = async_std::future::timeout(RECV_TIMEOUT, poll).await;
+        let Ok(result) = result else {
+            trace!("Timeout receiving a message");
+            return Ok(true)
+
+        };
+        let event = result?;
+        let Event::Incoming(Packet::Publish(publish)) = event else {
+            continue;
+        };
+
+        if publish.topic != opts.pong_topic {
+            continue;
+        }
+
+        break publish;
+    };
+
+    let info = match parse_payload(&publish.payload, opts.payload_size) {
+        Ok(info) => info,
+        Err(err) => {
+            error!("Unable to parse payload: {:#}", err);
+            return Ok(false);
+        }
+    };
+
+    trace!(
+        "Received a pong with ping_id {} and msg_idx {}",
+        info.ping_id,
+        info.msg_idx
+    );
+    ensure!(
+        info.ping_id == ping_id,
+        "Ignore the payload from a foreign ping ID {}",
+        info.ping_id
+    );
+
+    println!("{},{}", opts.interval, info.rtt.as_micros() / 2);
+
+    Ok(true)
+}

--- a/comparison/src/rumqttc/src/rumqttc_ping/opts.rs
+++ b/comparison/src/rumqttc/src/rumqttc_ping/opts.rs
@@ -1,0 +1,48 @@
+use anyhow::Result;
+use clap::{Parser, ValueEnum};
+use rumqttc_test::{DEFAULT_PING_TOPIC, DEFAULT_PONG_TOPIC};
+use std::{net::SocketAddr, time::Duration};
+
+#[derive(Parser)]
+pub struct Opts {
+    #[clap(long, default_value_t = DEFAULT_PING_TOPIC.to_string())]
+    pub ping_topic: String,
+    #[clap(long, default_value_t = DEFAULT_PONG_TOPIC.to_string())]
+    pub pong_topic: String,
+    #[clap(long, parse(try_from_str = parse_timeout))]
+    pub timeout: Option<Duration>,
+    #[clap(long, value_enum, default_value = "human")]
+    pub output_format: OutputFormat,
+
+    #[clap(short = 'b', long, default_value = "127.0.0.1:1883")]
+    pub broker: SocketAddr,
+
+    #[clap(short, long, help = "ping interval in seconds")]
+    pub interval: f64,
+
+    #[clap(short, long)]
+    pub payload_size: usize,
+    // #[clap(short = 'P', long)]
+    // pub producer_configs: Option<Vec<KeyVal>>,
+
+    // #[clap(short = 'C', long)]
+    // pub consumer_configs: Option<Vec<KeyVal>>,
+}
+
+fn parse_timeout(text: &str) -> Result<Duration> {
+    let dur = humantime::parse_duration(text)?;
+    Ok(dur)
+}
+
+// fn parse_interval(text: &str) -> Result<Duration> {
+//     let secs = R64::from_str_radix(text, 10).map_err(|_| anyhow!("invalid interval {}", text))?;
+//     let dur = Duration::from_secs_f64(secs.raw());
+//     Ok(dur)
+// }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
+#[clap(rename_all = "snake_case")]
+pub enum OutputFormat {
+    Human,
+    Json,
+}

--- a/comparison/src/rumqttc/src/rumqttc_pong/main.rs
+++ b/comparison/src/rumqttc/src/rumqttc_pong/main.rs
@@ -1,0 +1,56 @@
+mod opts;
+
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use log::{info, trace};
+use opts::Opts;
+use rumqttc::{AsyncClient, Event, MqttOptions, Packet};
+use rumqttc_test::{DEFAULT_CAP_SIZE, DEFAULT_QOS};
+use std::process;
+
+#[async_std::main]
+async fn main() -> Result<()> {
+    pretty_env_logger::init();
+
+    let opts = Opts::parse();
+    let timeout = opts.timeout;
+    let future = run_pong(opts);
+
+    if let Some(timeout) = timeout {
+        async_std::future::timeout(timeout, future)
+            .await
+            .map_err(|_| anyhow!("timeout"))??;
+    } else {
+        future.await?;
+    }
+
+    Ok(())
+}
+
+async fn run_pong(opts: Opts) -> Result<()> {
+    let pong_id = process::id();
+    info!("Start pong {}", pong_id);
+
+    let client_config = MqttOptions::new(
+        env!("CARGO_PKG_NAME"),
+        opts.broker.ip().to_string(),
+        opts.broker.port(),
+    );
+    let (client, mut event_loop) = AsyncClient::new(client_config, DEFAULT_CAP_SIZE);
+    client.subscribe(&opts.ping_topic, DEFAULT_QOS).await?;
+
+    loop {
+        let event = event_loop.poll().await?;
+        let Event::Incoming(Packet::Publish(publish)) =  event else {
+            continue;
+        };
+        if publish.topic != opts.ping_topic {
+            continue;
+        }
+
+        trace!("received a ping");
+        client
+            .publish(&opts.pong_topic, DEFAULT_QOS, false, publish.payload)
+            .await?;
+    }
+}

--- a/comparison/src/rumqttc/src/rumqttc_pong/main.rs
+++ b/comparison/src/rumqttc/src/rumqttc_pong/main.rs
@@ -4,20 +4,21 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use log::{info, trace};
 use opts::Opts;
-use rumqttc::{AsyncClient, Event, MqttOptions, Packet};
-use rumqttc_test::{DEFAULT_CAP_SIZE, DEFAULT_QOS};
+use rumqttc::{Event, Packet};
+use rumqttc_test::{create_client, DEFAULT_QOS};
 use std::process;
+use tokio::time::timeout;
 
-#[async_std::main]
+#[tokio::main]
 async fn main() -> Result<()> {
     pretty_env_logger::init();
 
     let opts = Opts::parse();
-    let timeout = opts.timeout;
+    let timeout_dur = opts.timeout;
     let future = run_pong(opts);
 
-    if let Some(timeout) = timeout {
-        async_std::future::timeout(timeout, future)
+    if let Some(timeout_dur) = timeout_dur {
+        timeout(timeout_dur, future)
             .await
             .map_err(|_| anyhow!("timeout"))??;
     } else {
@@ -31,12 +32,8 @@ async fn run_pong(opts: Opts) -> Result<()> {
     let pong_id = process::id();
     info!("Start pong {}", pong_id);
 
-    let client_config = MqttOptions::new(
-        env!("CARGO_PKG_NAME"),
-        opts.broker.ip().to_string(),
-        opts.broker.port(),
-    );
-    let (client, mut event_loop) = AsyncClient::new(client_config, DEFAULT_CAP_SIZE);
+    let (client, mut event_loop) =
+        create_client(env!("CARGO_BIN_NAME"), opts.broker, opts.max_payload_size)?;
     client.subscribe(&opts.ping_topic, DEFAULT_QOS).await?;
 
     loop {

--- a/comparison/src/rumqttc/src/rumqttc_pong/opts.rs
+++ b/comparison/src/rumqttc/src/rumqttc_pong/opts.rs
@@ -7,19 +7,18 @@ use std::{net::SocketAddr, time::Duration};
 pub struct Opts {
     #[clap(long, default_value_t = DEFAULT_PING_TOPIC.to_string())]
     pub ping_topic: String,
+
     #[clap(long, default_value_t = DEFAULT_PONG_TOPIC.to_string())]
     pub pong_topic: String,
+
     #[clap(long, parse(try_from_str = parse_duration))]
     pub timeout: Option<Duration>,
 
-    // public options
     #[clap(short = 'b', long, default_value = "127.0.0.1:1883")]
     pub broker: SocketAddr,
-    // #[clap(short = 'P', long)]
-    // pub producer_configs: Option<Vec<KeyVal>>,
 
-    // #[clap(short = 'C', long)]
-    // pub consumer_configs: Option<Vec<KeyVal>>,
+    #[clap(long, default_value = "2147483648")]
+    pub max_payload_size: usize,
 }
 
 fn parse_duration(text: &str) -> Result<Duration> {

--- a/comparison/src/rumqttc/src/rumqttc_pong/opts.rs
+++ b/comparison/src/rumqttc/src/rumqttc_pong/opts.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use clap::Parser;
+use rumqttc_test::{DEFAULT_PING_TOPIC, DEFAULT_PONG_TOPIC};
+use std::{net::SocketAddr, time::Duration};
+
+#[derive(Parser)]
+pub struct Opts {
+    #[clap(long, default_value_t = DEFAULT_PING_TOPIC.to_string())]
+    pub ping_topic: String,
+    #[clap(long, default_value_t = DEFAULT_PONG_TOPIC.to_string())]
+    pub pong_topic: String,
+    #[clap(long, parse(try_from_str = parse_duration))]
+    pub timeout: Option<Duration>,
+
+    // public options
+    #[clap(short = 'b', long, default_value = "127.0.0.1:1883")]
+    pub broker: SocketAddr,
+    // #[clap(short = 'P', long)]
+    // pub producer_configs: Option<Vec<KeyVal>>,
+
+    // #[clap(short = 'C', long)]
+    // pub consumer_configs: Option<Vec<KeyVal>>,
+}
+
+fn parse_duration(text: &str) -> Result<Duration> {
+    let dur = humantime::parse_duration(text)?;
+    Ok(dur)
+}

--- a/comparison/src/rumqttc/src/rumqttc_pub_thr/main.rs
+++ b/comparison/src/rumqttc/src/rumqttc_pub_thr/main.rs
@@ -1,0 +1,63 @@
+mod opts;
+
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use itertools::chain;
+use log::{info, trace};
+use opts::Opts;
+use rumqttc::{AsyncClient, MqttOptions};
+use rumqttc_test::{DEFAULT_CAP_SIZE, DEFAULT_QOS};
+use std::{iter, process};
+
+#[async_std::main]
+async fn main() -> Result<()> {
+    pretty_env_logger::init();
+
+    let opts = Opts::parse();
+    let timeout = opts.timeout;
+
+    let future = run_producer(opts);
+    if let Some(timeout) = timeout {
+        async_std::future::timeout(timeout, future)
+            .await
+            .map_err(|_| anyhow!("timeout"))??;
+    } else {
+        future.await?;
+    }
+
+    Ok(())
+}
+
+async fn run_producer(opts: Opts) -> Result<()> {
+    let producer_id = process::id();
+    info!("Start producer {} on topic {}", producer_id, opts.topic);
+
+    // Configure the client
+    let client_config = MqttOptions::new(
+        env!("CARGO_PKG_NAME"),
+        opts.broker.ip().to_string(),
+        opts.broker.port(),
+    );
+    let (client, _event_loop) = AsyncClient::new(client_config, DEFAULT_CAP_SIZE);
+    client.subscribe(&opts.topic, DEFAULT_QOS).await?;
+
+    for msg_idx in 0.. {
+        let payload = generate_payload(producer_id, msg_idx as u32, opts.payload_size);
+        trace!("Producer {} sends a message {}", producer_id, msg_idx);
+        client
+            .publish(&opts.topic, DEFAULT_QOS, false, payload)
+            .await?;
+    }
+
+    Ok(())
+}
+
+pub fn generate_payload(producer_id: u32, msg_index: u32, payload_size: usize) -> Vec<u8> {
+    let producer_id_bytes: [u8; 4] = producer_id.to_le_bytes();
+    let msg_idx_bytes: [u8; 4] = (msg_index as u32).to_le_bytes();
+    let pad_bytes = {
+        let pad_size = payload_size - producer_id_bytes.len() - msg_idx_bytes.len();
+        iter::repeat(0u8).take(pad_size)
+    };
+    chain!(producer_id_bytes, msg_idx_bytes, pad_bytes).collect()
+}

--- a/comparison/src/rumqttc/src/rumqttc_pub_thr/opts.rs
+++ b/comparison/src/rumqttc/src/rumqttc_pub_thr/opts.rs
@@ -1,0 +1,31 @@
+use anyhow::Result;
+use clap::{Parser, ValueEnum};
+use rumqttc_test::DEFAULT_THROUGHPUT_TOPIC;
+use std::{net::SocketAddr, time::Duration};
+
+#[derive(Parser)]
+pub struct Opts {
+    #[clap(long, default_value_t = DEFAULT_THROUGHPUT_TOPIC.to_string())]
+    pub topic: String,
+    #[clap(long, parse(try_from_str = parse_duration))]
+    pub timeout: Option<Duration>,
+
+    #[clap(short = 'b', long, default_value = "127.0.0.1:1883")]
+    pub broker: SocketAddr,
+    #[clap(short = 'p', long)]
+    pub payload_size: usize,
+    // #[clap(short = 'P', long)]
+    // pub producer_configs: Option<Vec<KeyVal>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
+#[clap(rename_all = "snake_case")]
+pub enum Mode {
+    Peer,
+    Client,
+}
+
+fn parse_duration(text: &str) -> Result<Duration> {
+    let dur = humantime::parse_duration(text)?;
+    Ok(dur)
+}

--- a/comparison/src/rumqttc/src/rumqttc_sub_thr/main.rs
+++ b/comparison/src/rumqttc/src/rumqttc_sub_thr/main.rs
@@ -1,0 +1,124 @@
+mod opts;
+
+use async_std::{sync::Arc, task};
+use rumqttc::{AsyncClient, Event, MqttOptions, Packet};
+use std::{
+    process,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::{Duration, Instant},
+};
+
+use anyhow::{anyhow, ensure, Result};
+use clap::Parser;
+use log::{error, info, trace};
+use opts::Opts;
+use rumqttc_test::{DEFAULT_CAP_SIZE, DEFAULT_QOS};
+
+#[async_std::main]
+async fn main() -> Result<()> {
+    pretty_env_logger::init();
+
+    let opts = Opts::parse();
+    let timeout = opts.timeout;
+
+    let future = run_consumer(opts);
+    if let Some(timeout) = timeout {
+        async_std::future::timeout(timeout, future)
+            .await
+            .map_err(|_| anyhow!("timeout"))??;
+    } else {
+        future.await?;
+    }
+
+    Ok(())
+}
+
+async fn run_consumer(opts: Opts) -> Result<()> {
+    let consumer_id = process::id();
+    info!("Start consumer {} on topic {}", consumer_id, opts.topic);
+
+    // Configure the client
+    let client_config = MqttOptions::new(
+        env!("CARGO_PKG_NAME"),
+        opts.broker.ip().to_string(),
+        opts.broker.port(),
+    );
+    let (client, mut event_loop) = AsyncClient::new(client_config, DEFAULT_CAP_SIZE);
+    client.subscribe(&opts.topic, DEFAULT_QOS).await?;
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    async_std::task::spawn(measure(counter.clone(), opts.payload_size));
+
+    loop {
+        let event = event_loop.poll().await?;
+        let Event::Incoming(Packet::Publish(publish)) = event else {
+            continue;
+        };
+
+        if publish.topic != opts.topic {
+            continue;
+        }
+
+        // decode the producer ID and message index in the payload
+        let info = match parse_payload(&publish.payload, opts.payload_size) {
+            Ok(info) => info,
+            Err(err) => {
+                error!("Unable to parse payload: {:?}", err);
+                continue;
+            }
+        };
+        trace!(
+            "Consumer {} receives a payload with index {} and size {} from producer {}",
+            consumer_id,
+            info.msg_index,
+            publish.payload.len(),
+            info.producer_id
+        );
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+pub fn parse_payload(payload: &[u8], expect_size: usize) -> Result<PayloadInfo> {
+    let payload_size = payload.len();
+    ensure!(
+        payload_size >= 8,
+        "insufficient payload size {}",
+        payload_size
+    );
+    ensure!(
+        payload_size == expect_size,
+        "payload size does not match, expect {} bytes, but received {} bytes",
+        expect_size,
+        payload_size
+    );
+
+    let producer_id = u32::from_le_bytes(payload[0..4].try_into().unwrap());
+    let msg_index = u32::from_le_bytes(payload[4..8].try_into().unwrap());
+
+    Ok(PayloadInfo {
+        producer_id,
+        msg_index,
+        payload_size,
+    })
+}
+
+#[derive(Debug, Clone)]
+pub struct PayloadInfo {
+    pub producer_id: u32,
+    pub msg_index: u32,
+    pub payload_size: usize,
+}
+
+async fn measure(messages: Arc<AtomicUsize>, payload: usize) {
+    let mut timer = Instant::now();
+    loop {
+        task::sleep(Duration::from_secs(1)).await;
+
+        if messages.load(Ordering::Relaxed) > 0 {
+            let elapsed = timer.elapsed().as_micros() as f64;
+            let c = messages.swap(0, Ordering::Relaxed);
+            println!("{},{:.3}", payload, c as f64 * 1_000_000.0 / elapsed);
+            timer = Instant::now()
+        }
+    }
+}

--- a/comparison/src/rumqttc/src/rumqttc_sub_thr/opts.rs
+++ b/comparison/src/rumqttc/src/rumqttc_sub_thr/opts.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+use clap::{Parser, ValueEnum};
+use rumqttc_test::DEFAULT_THROUGHPUT_TOPIC;
+use std::{net::SocketAddr, time::Duration};
+
+#[derive(Parser)]
+pub struct Opts {
+    #[clap(long, default_value_t = DEFAULT_THROUGHPUT_TOPIC.to_string())]
+    pub topic: String,
+    #[clap(long, parse(try_from_str = parse_duration))]
+    pub timeout: Option<Duration>,
+    #[clap(long, value_enum, default_value = "human")]
+    pub output_format: OutputFormat,
+
+    // pub no_multicast_scouting: bool,
+
+    // public options
+    #[clap(short = 'b', long, default_value = "127.0.0.1:1883")]
+    pub broker: SocketAddr,
+    #[clap(short = 'p', long)]
+    pub payload_size: usize,
+
+    #[clap(long, default_value = "0")]
+    pub warmup_msgs: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
+#[clap(rename_all = "snake_case")]
+pub enum Mode {
+    Peer,
+    Client,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
+#[clap(rename_all = "snake_case")]
+pub enum OutputFormat {
+    Human,
+    Json,
+}
+
+fn parse_duration(text: &str) -> Result<Duration> {
+    let dur = humantime::parse_duration(text)?;
+    Ok(dur)
+}


### PR DESCRIPTION
This PR adds throughput and latency test for rumqttcc, a Rust-implementation of MQTT client. The code was borrowed and rewritten from kafka comparison tests.