### PR TITLE
Tidy Kafka comparison code

### DIFF
--- a/comparison/kafka/src/kafka_ping/main.rs
+++ b/comparison/kafka/src/kafka_ping/main.rs
@@ -131,8 +131,6 @@ fn create_consumer(
     topic: &str,
 ) -> Result<AsyncStdStreamConsumer> {
     config
-        // .set("enable.partition.eof", "false")
-        // .set("enable.auto.commit", "false")
         .set("group.id", DEFAULT_GROUP_ID)
         .set("session.timeout.ms", "6000");
 
@@ -233,7 +231,6 @@ async fn recv(
             Ok(true)
         }
         Ok(Err(E::MessageConsumption(C::UnknownTopicOrPartition))) => {
-            // retry
             trace!(
                 "The topic {} is not created yet, retry again",
                 opts.pong_topic

--- a/comparison/kafka/src/kafka_ping/main.rs
+++ b/comparison/kafka/src/kafka_ping/main.rs
@@ -52,9 +52,6 @@ async fn run_latency_benchmark(opts: Opts) -> Result<()> {
     };
     info!("Start ping {}", ping_id);
 
-    // let producer = ping_producer(&opts, &client_config, ping_id);
-    // let consumer = pong_consumer(&opts, &client_config, ping_id);
-    // try_join!(producer, consumer)?;
     run_ping_pong(&opts, &client_config, ping_id).await?;
 
     Ok(())

--- a/comparison/kafka/src/kafka_ping/opts.rs
+++ b/comparison/kafka/src/kafka_ping/opts.rs
@@ -35,12 +35,6 @@ fn parse_timeout(text: &str) -> Result<Duration> {
     Ok(dur)
 }
 
-// fn parse_interval(text: &str) -> Result<Duration> {
-//     let secs = R64::from_str_radix(text, 10).map_err(|_| anyhow!("invalid interval {}", text))?;
-//     let dur = Duration::from_secs_f64(secs.raw());
-//     Ok(dur)
-// }
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
 #[clap(rename_all = "snake_case")]
 pub enum OutputFormat {

--- a/comparison/kafka/src/kafka_pong/main.rs
+++ b/comparison/kafka/src/kafka_pong/main.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<()> {
     pretty_env_logger::init();
 
     let opts = Opts::parse();
-
     let timeout = opts.timeout;
-
     let future = run_pong(opts);
 
     if let Some(timeout) = timeout {
@@ -99,8 +97,6 @@ async fn run_pong(opts: Opts) -> Result<()> {
             .await
             .map_err(|(err, _msg)| err)?;
     }
-
-    Ok(())
 }
 
 fn create_consumer(
@@ -109,8 +105,6 @@ fn create_consumer(
     topic: &str,
 ) -> Result<AsyncStdStreamConsumer> {
     config
-        // .set("enable.partition.eof", "false")
-        // .set("enable.auto.commit", "false")
         .set("group.id", DEFAULT_GROUP_ID)
         .set("session.timeout.ms", "6000");
 
@@ -124,78 +118,3 @@ fn create_consumer(
     consumer.subscribe(&[topic])?;
     Ok(consumer)
 }
-
-// async fn ping_consumer(
-//     opts: &Opts,
-//     client_config: &ClientConfig,
-//     topic: &str,
-//     tx: mpsc::Sender<OwnedMessage>,
-// ) -> Result<()> {
-//     use KafkaError as E;
-//     use RDKafkaErrorCode as C;
-
-//     let mut consumer: StreamConsumer = create_consumer(&opts, client_config.clone(), topic)?;
-
-//     loop {
-//         let msg = loop {
-//             let result = consumer.recv().await;
-//             match result {
-//                 Ok(msg) => break msg.detach(),
-//                 Err(E::MessageConsumption(C::UnknownTopicOrPartition)) => {
-//                     // retry
-//                     trace!("The topic {} is not created yet, retry again", topic);
-//                     async_std::task::sleep(Duration::from_secs(1)).await;
-//                     consumer = create_consumer(&opts, client_config.clone(), topic)?;
-//                     continue;
-//                 }
-//                 Err(err) => return Err(err.into()),
-//             }
-//         };
-
-//         trace!("received a ping");
-
-//         let result = tx.send(msg).await;
-//         if result.is_err() {
-//             break;
-//         }
-//     }
-
-//     Ok(())
-// }
-
-// async fn pong_producer(
-//     opts: &Opts,
-//     client_config: &ClientConfig,
-//     topic: &str,
-//     pong_id: u32,
-//     mut rx: mpsc::Receiver<OwnedMessage>,
-// ) -> Result<()> {
-//     let record_key = pong_id.to_le_bytes();
-//     let mut client_config = client_config.clone();
-//     if let Some(cfgs) = &opts.producer_configs {
-//         cfgs.iter().for_each(|kv| {
-//             client_config.set(&kv.key, &kv.val);
-//         });
-//     }
-//     let producer: FutureProducer = client_config.create()?;
-
-//     while let Some(msg) = rx.recv().await {
-//         let payload = match msg.payload() {
-//             Some(payload) => payload,
-//             None => {
-//                 warn!("the payload does not present in the received message");
-//                 continue;
-//             }
-//         };
-
-//         let record = FutureRecord::to(topic).payload(payload).key(&record_key);
-
-//         trace!("send a pong");
-//         producer
-//             .send(record, Duration::ZERO)
-//             .await
-//             .map_err(|(err, _msg)| err)?;
-//     }
-
-//     Ok(())
-// }

--- a/comparison/kafka/src/kafka_pong/main.rs
+++ b/comparison/kafka/src/kafka_pong/main.rs
@@ -33,7 +33,6 @@ async fn main() -> Result<()> {
 async fn run_pong(opts: Opts) -> Result<()> {
     let pong_id = process::id();
     info!("Start pong {}", pong_id);
-    // let record_key = pong_id.to_le_bytes();
 
     let client_config = {
         let mut conf = ClientConfig::new();

--- a/comparison/kafka/src/kafka_pub_thr/main.rs
+++ b/comparison/kafka/src/kafka_pub_thr/main.rs
@@ -1,14 +1,12 @@
 mod opts;
 
-use std::{iter, process, time::Duration};
-
 use anyhow::{anyhow, Result};
 use clap::Parser;
-use itertools::chain;
 use kafka_test::AsyncStdFutureProducer;
 use log::{info, trace};
 use opts::Opts;
 use rdkafka::{producer::FutureRecord, ClientConfig};
+use std::{process, time::Duration};
 
 #[async_std::main]
 async fn main() -> Result<()> {
@@ -44,16 +42,6 @@ async fn run_producer(opts: Opts) -> Result<()> {
     }
 
     let producer: AsyncStdFutureProducer = client_config.create()?;
-
-    // let producer: FutureProducer = ClientConfig::new()
-    //     .set("bootstrap.servers", &opts.brokers)
-    //     .set("message.timeout.ms", "5000")
-    //     .set("linger.ms", "0")
-    //     .set("batch.size", "200KB")
-    //     .set("compression.type", "lz4")
-    //     .set("acks", "1")
-    //     // .set("metadata.max.age.ms", "180000")
-    //     .create()?;
 
     for msg_idx in 0.. {
         let key = producer_id.to_le_bytes();

--- a/comparison/kafka/src/kafka_pub_thr/main.rs
+++ b/comparison/kafka/src/kafka_pub_thr/main.rs
@@ -42,10 +42,10 @@ async fn run_producer(opts: Opts) -> Result<()> {
     }
 
     let producer: AsyncStdFutureProducer = client_config.create()?;
+    let payload: Vec<u8> = (0..opts.payload_size).map(|i| (i % 10) as u8).collect();
 
     for msg_idx in 0.. {
         let key = producer_id.to_le_bytes();
-        let payload = generate_payload(producer_id, msg_idx as u32, opts.payload_size);
         let record = FutureRecord::to(&opts.topic).payload(&payload).key(&key);
 
         trace!("Producer {} sends a message {}", producer_id, msg_idx);
@@ -56,14 +56,4 @@ async fn run_producer(opts: Opts) -> Result<()> {
     }
 
     Ok(())
-}
-
-pub fn generate_payload(producer_id: u32, msg_index: u32, payload_size: usize) -> Vec<u8> {
-    let producer_id_bytes: [u8; 4] = producer_id.to_le_bytes();
-    let msg_idx_bytes: [u8; 4] = (msg_index as u32).to_le_bytes();
-    let pad_bytes = {
-        let pad_size = payload_size - producer_id_bytes.len() - msg_idx_bytes.len();
-        iter::repeat(0u8).take(pad_size)
-    };
-    chain!(producer_id_bytes, msg_idx_bytes, pad_bytes).collect()
 }

--- a/comparison/kafka/src/kafka_sub_thr/main.rs
+++ b/comparison/kafka/src/kafka_sub_thr/main.rs
@@ -101,7 +101,6 @@ async fn run_consumer(opts: Opts) -> Result<()> {
         );
         counter.fetch_add(1, Ordering::Relaxed);
     }
-    Ok(())
 }
 
 pub fn parse_payload(payload: &[u8], expect_size: usize) -> Result<PayloadInfo> {

--- a/comparison/kafka/src/kafka_sub_thr/main.rs
+++ b/comparison/kafka/src/kafka_sub_thr/main.rs
@@ -1,16 +1,15 @@
 mod opts;
 
 use async_std::{sync::Arc, task};
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{
     process,
+    sync::atomic::{AtomicUsize, Ordering},
     time::{Duration, Instant},
 };
 
 use anyhow::{anyhow, ensure, Result};
 use clap::Parser;
-use kafka_test::AsyncStdStreamConsumer;
-use kafka_test::DEFAULT_GROUP_ID;
+use kafka_test::{AsyncStdStreamConsumer, DEFAULT_GROUP_ID};
 use log::{error, info, trace};
 use opts::Opts;
 use rdkafka::{
@@ -51,9 +50,7 @@ async fn run_consumer(opts: Opts) -> Result<()> {
         let consumer: AsyncStdStreamConsumer = ClientConfig::new()
             .set("bootstrap.servers", &opts.brokers)
             .set("group.id", DEFAULT_GROUP_ID)
-            // .set("enable.partition.eof", "false")
             .set("session.timeout.ms", "6000")
-            // .set("enable.auto.commit", "false")
             .create()?;
         consumer.subscribe(&[&opts.topic])?;
         Ok(consumer)

--- a/comparison/kafka/src/kafka_sub_thr/opts.rs
+++ b/comparison/kafka/src/kafka_sub_thr/opts.rs
@@ -11,10 +11,6 @@ pub struct Opts {
     pub timeout: Option<Duration>,
     #[clap(long, value_enum, default_value = "human")]
     pub output_format: OutputFormat,
-
-    // pub no_multicast_scouting: bool,
-
-    // public options
     #[clap(short = 'b', long, default_value = "127.0.0.1")]
     pub brokers: String,
     #[clap(short = 'p', long)]


### PR DESCRIPTION
This PR intends to improve the code quality of Kafka comparison benchmark. Additionally, it removes payload generation in Kafka throughput test and resues the buffer instead.
